### PR TITLE
ポートフォリオのリンク先を別タブで開く

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -57,7 +57,7 @@
         </div>
     </div>
     <div class="mb-3">
-        <%= link_to @post.github_url, @post.github_url %>
+        <%= link_to @post.github_url, @post.github_url, target: :_blank, rel: "noopener noreferrer" %>
     </div>
 <% end %>
 
@@ -68,7 +68,7 @@
         </div>
     </div>
     <div class="mb-3">
-        <%= link_to @post.app_url, @post.app_url %>
+        <%= link_to @post.app_url, @post.app_url, target: :_blank, rel: "noopener noreferrer" %>
     </div>
 <% end %>
 


### PR DESCRIPTION
ユーザーが閲覧を続けやすくするためにgithubやアプリケーションのURLを開く時、別タブで開くように変更